### PR TITLE
Read directory and return array of file contents

### DIFF
--- a/mockserver/fileReader.js
+++ b/mockserver/fileReader.js
@@ -1,14 +1,20 @@
 var fs = require('fs');
-var data;
+var data = [];
 
 try {
     //var data = fs.readFileSync('C://WORK//PaceDev//Sample//html_faqs15.html', 'utf8');
-    var data = fs.readFileSync('C://WORK//PaceDev//Sample//splashscreentemplate.html', 'utf8');
+    var testFolder = 'C://WORK//PaceDev//Sample//';
+    fs.readdirSync(testFolder).forEach(
+        file => {
+            var fileData = fs.readFileSync(testFolder + file, 'utf8');
+            data.push({
+                "content": fileData
+            });
+        });
 } catch (error) {
     data = null;
 }
 
-const response = {"metadata": {
-                    "content": data
-                 }};
+console.log("Directory Access:", data.length + " file content/s retrieved.");
+const response = {"metadata": data};
 module.exports = response;

--- a/mockserver/server.ts
+++ b/mockserver/server.ts
@@ -1,7 +1,6 @@
 const jsonServer = require("json-server");
 const server = jsonServer.create();
 const res = require('./fileReader.js');
-console.log("response data ",res);
 const router = jsonServer.router(res);
 const middlewares = jsonServer.defaults();
 const cors = require("cors");


### PR DESCRIPTION
Converted api response into array. Can now read all files within the provided directory.

```
[
     {
        content: "file content 1"
     },
     {
        content: "file content 2"
     },
     ...
]
```